### PR TITLE
Updated pyproject.toml file to include deps needed for qwen2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,10 @@ dependencies = [
     "polars>=0.20.22",
     "bm25s>=0.0.0",
     "PyStemmer>=0.0.0",
-    "oci>=0.0.0",
-    "torchvision>=0.0.0"
+    "oci>=0.0.0",    
+    "torchvision>=0.0.0",
+    "qwen-vl-utils>=0.0.0",
+    "accelerate>=0.0.0"
 ]
 
 


### PR DESCRIPTION
## Changed
- `pyproject.toml` to include missing deps for running qwen2.5 eval.

## Verification
- Successfully ran the `scripts/oci/notebooks/qwen2.5_benchmark.ipynb` notebook.
- Had to create venv in PHX with other missing deps that cannot be pinned in `pyproject.toml` due to index-url needed, to recreate venv to be used by the jupyter server:
```
. set_proxy
cd ~/code/mteb
python3.11 -m venv venv_py311
source venv_py311/bin/activate
pip install .
pip install torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 --index-url https://download.pytorch.org/whl/cu124
pip install flash-attn --no-build-isolation  # needs CUDA 12.4
```